### PR TITLE
Add Splitwise for YNAB

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ A list of awesome YNAB projects. A lot of these projects use the YNAB API, and c
 
 - [Cryptonabber Offramp](https://github.com/jrh3k5/cryptonabber-offramp) A tool used to automate the tracking of converting cryptocurrencies from accounts into fiat accounts
 
+- [Splitwise for YNAB](https://www.splitwiseforynab.com) Sync shared expenses with your partner between YNAB and Splitwise
+
 ### Submit a Project
 
 To submit a project, please submit a pull request.


### PR DESCRIPTION
I’ve been tracking my shared expenses with my partner using a Splitwise cash account for a while. I personally find it easier to manage than support's [Splitwise in Your Register](https://support.ynab.com/en_us/splitwise-and-ynab-a-guide-H1GwOyuCq) suggestion.

Repo: https://github.com/danthareja/splitwise_for_ynab